### PR TITLE
Add conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feel free to add your own record, fix erroneous data and add additional fields.
 
 ## User Groups
 
-The file user-groups.json lists all user groups. Leave "last_meetup" blank if still active.
+The file /data/user-groups.json lists all user groups. Leave "last_meetup" blank if still active.
 
 ```json
 {
@@ -28,3 +28,39 @@ The file user-groups.json lists all user groups. Leave "last_meetup" blank if st
     "calendar_feed": "http://example.com/feed.rss"
 }
 ```
+
+## Conferences
+
+The file /data/conferences.json lists all user conferences. Leave "last_event" blank if still active.
+
+[
+    {
+        "key": "example",
+        "name": "Full conference name",
+        "tags": ["ruby"],
+        "first_event": "yyyy-mm-dd",
+        "last_event": "",
+        "events": [
+            {
+                "name": "Name of specific edition",
+                "location": {
+                    "name": "City, State (if applies), Country"
+                },
+                "event_start": "yyyy-mm-dd",
+                "event_end": "yyyy-mm-dd",
+                "cfp_start": "yyyy-mm-dd",
+                "cfp_end": "yyyy-mm-dd",
+                "session_feed": "https://example.com/2016/sessions.json",
+                "speaker_feed": "https://example.com/2016/speakers.json",
+                "organizers": [
+                    {
+                        "name": "Organizer Name",
+                        "twitter": "@twitter_handle"
+                    }
+                ]
+            }
+        ],
+        "website": "https://example.com",
+        "twitter": "@twitter_handle"
+    }
+]

--- a/data/conferences.json
+++ b/data/conferences.json
@@ -2,7 +2,7 @@
     {
         "key": "confoo",
         "name": "ConFoo",
-        "tags": ["php"],
+        "tags": ["php", "dotnet", "accessibility", "databases", "devops", "html", "css", "iot", "java", "js", "ecommerce", "nodejs", "mobile", "ruby", "performance", "quality", "security"],
         "first_event": "2010-03-08",
         "last_event": "",
         "events": [

--- a/data/conferences.json
+++ b/data/conferences.json
@@ -1,0 +1,45 @@
+[
+    {
+        "key": "confoo",
+        "name": "ConFoo",
+        "tags": ["php"],
+        "first_event": "2010-03-08",
+        "last_event": "",
+        "events": [
+            {
+                "name": "ConFoo 2010",
+                "location": {
+                    "name": "Montreal, QC, Canada"
+                },
+                "event_start": "2010-03-08",
+                "event_end": "2010-03-12",
+                "session_feed": "https://confoo.ca/2010/sessions.json",
+                "speaker_feed": "https://confoo.ca/2010/speakers.json"
+            },
+            {
+                "name": "ConFoo 2016",
+                "location": {
+                    "name": "Montreal, QC, Canada"
+                },
+                "event_start": "2016-02-22",
+                "event_end": "2016-02-26",
+                "cfp_start": "2015-08-21",
+                "cfp_end": "2015-09-20",
+                "session_feed": "https://confoo.ca/2016/sessions.json",
+                "speaker_feed": "https://confoo.ca/2016/speakers.json",
+                "organizers": [
+                    {
+                        "name": "Yann Larrivée",
+                        "twitter": "@ylarrivee"
+                    },
+                    {
+                        "name": "Anna Filina",
+                        "twitter": "@afilina"
+                    }
+                ]
+            }
+        ],
+        "website": "https://confoo.ca",
+        "twitter": "@confooca"
+    }
+]

--- a/test/JsonTest.php
+++ b/test/JsonTest.php
@@ -2,9 +2,21 @@
 
 class JsonTest extends PHPUnit_Framework_TestCase
 {
-    public function testJson()
+    public function testJsonUserGroups()
     {
         $filePath = dirname(__FILE__) . '/../data/user-groups.json';
+
+        $this->assertFileExists($filePath);
+
+        $data = json_decode(file_get_contents($filePath), true);
+
+        $this->assertEquals(JSON_ERROR_NONE, json_last_error());
+        $this->assertGreaterThan(0, count($data));
+    }
+
+    public function testJsonConferences()
+    {
+        $filePath = dirname(__FILE__) . '/../data/conferences.json';
 
         $this->assertFileExists($filePath);
 


### PR DESCRIPTION
Let's also list all conferences.
- Event dates help other conferences to avoid clashes.
- Call for papers dates will remove the need for manually scanning all sites.
- Each conference can provide a list of talks and speakers, handy for @joindin and Lanyrd type of sites. Already implemented the list for ConFoo, so you can use it as an example.
