### PR TITLE
Add Open Code to the list of user groups

### DIFF
--- a/data/user-groups.json
+++ b/data/user-groups.json
@@ -526,5 +526,18 @@
         "website": "meetup.com/PHP-Leuven-Web-Innovation-Group/",
         "twitter": "@phpleuven",
         "calendar_feed": "http://www.meetup.com/PHP-Leuven-Web-Innovation-Group/events/rss/"
+    },
+    {
+        "name": "Open Code",
+        "tags": [],
+        "first_meetup": "2011-07-28",
+        "last_meetup": "",
+        "locations": [
+            {
+                "name": "Quebec, QC, Canada"
+            }
+        ],
+        "website": "http://www.opencode.ca/",
+        "twitter": "@opencodeqc"
     }
 ]


### PR DESCRIPTION
Not sure what I should put in the tags, the user group is not language specific and covers everything from Node.js to Erlang, Azure to AWS, map technologies, patterns, etc.
