### PR TITLE
Atmosphere Conference updated website addres

### DIFF
--- a/data/conferences.json
+++ b/data/conferences.json
@@ -33,7 +33,7 @@
                 ]
             }
         ],
-        "website": "https://atmosphere-conference.com",
+        "website": "http://atmosphere-conference.com",
         "twitter": "@atmosphereconf"
     },
     {


### PR DESCRIPTION
 Their https is not working apparently for now, so it's better to send users to http address. Sorry for this little thing. 