### PR TITLE
Propose a first cut of data normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,15 @@ Tip: add your entry to the top of file to avoid merge conflicts.  Required field
 ```json
 [
     {
-        "key": "example",
+        "key": "uniquekey",
         "name": "Full conference name",
+        "website": "https://example.com",
+        "languages": "English",
+        "twitter": "@twitter_handle",
+        "facebook": "https://www.facebook.com/page_name",
+        "code_of_conduct": "https://example.com/coc",
+        "accessibility": "https://example.com/accessible",
+        "diversitytickets_url": "https://example.com/diversitytix",
         "tags": ["ruby"],
         "first_event": "yyyy-mm-dd",
         "last_event": "",
@@ -67,6 +74,7 @@ Tip: add your entry to the top of file to avoid merge conflicts.  Required field
                 "session_feed": "https://example.com/2016/sessions.json",
                 "speaker_feed": "https://example.com/2016/speakers.json",
                 "hashtag": "#hashtag",
+                "youtube": "https://youtube.com/playlist",
                 "organizers": [
                     {
                         "name": "Organizer Name",
@@ -74,9 +82,7 @@ Tip: add your entry to the top of file to avoid merge conflicts.  Required field
                     }
                 ]
             }
-        ],
-        "website": "https://example.com",
-        "twitter": "@twitter_handle"
+        ]
     }
 ]
 ```


### PR DESCRIPTION
I think this is the best way to merge the codeandtalk data into a single JSON structure, at least from my perspective of the data I'd like to see.

This assumes the general case is languages, COC, accessibility statement, and any diversity-related ticket policies are all per event series, not just for a single event.  youtube channel would be for a single event, however.
For my purposes, a diversitytickets_url is sufficient for the general case.  It can point to some number on that website or could point to this conference's own diversity ticketing/support information.  That's sufficient for most of the need that I see, although I might be wrong about the volume of people looking for more specific data there.

Note: this does point out the structural difference between the two, and a decision to make:
- [ ] Have a single apachecon.json file for each event series, using this format, or:
- [ ] Have multiple apachecon2017.json ... files for each individual *event*, taking out the "events" sub-hash.

Personally I vote for the one file per event series, but it's up to you two with the existing codebases. 
