### PR TITLE
Update first meeting PHPUGFFM

### DIFF
--- a/data/user-groups.json
+++ b/data/user-groups.json
@@ -490,7 +490,6 @@
         "twitter": "@phpugffm",
         "mastodon": "@phpugffm@phpc.social",
         "calendar_feed": "https://phpugffm.de/events.ics"
-    }
     },
     {
         "key": "afup",

--- a/data/user-groups.json
+++ b/data/user-groups.json
@@ -485,7 +485,12 @@
         "key": "frankfurtphp",
         "name": "The Frankfurt PHPUG",
         "tags": ["php"],
-        "first_event": "2001-09-07"
+        "first_event": "2001-09-07",
+        "website": "https://phpugffm.de",
+        "twitter": "@phpugffm",
+        "mastodon": "@phpugffm@phpc.social",
+        "calendar_feed": "https://phpugffm.de/events.ics"
+    }
     },
     {
         "key": "afup",

--- a/data/user-groups.json
+++ b/data/user-groups.json
@@ -485,7 +485,7 @@
         "key": "frankfurtphp",
         "name": "The Frankfurt PHPUG",
         "tags": ["php"],
-        "first_event": "2001-12-01"
+        "first_event": "2001-09-07"
     },
     {
         "key": "afup",


### PR DESCRIPTION
According to the WayBack machine the first meeting that we know of reliably was on the 7th of September 2001

https://web.archive.org/web/20010923152504/http://www.phpug-ffm.de:80/